### PR TITLE
Fix missing messages

### DIFF
--- a/whatsapp.js
+++ b/whatsapp.js
@@ -82,7 +82,7 @@ function displayConversationMessages(id) {
 
   while(stmt.step()) {
     row = stmt.getAsObject();
-    if (row['ZGROUPEVENTTYPE'] != 0 || !row['ZTEXT']) {
+    if (!row['ZTEXT']) {
       continue;
     }
 


### PR DESCRIPTION
Some of my messages have `ZGROUPEVENTTYPE == 2`, so they get excluded. 
This causes my conversations to suddenly drop the replies from other people.
Removing this condition seems to fix this